### PR TITLE
feat: The "session request" is no longer managed by the client. 

### DIFF
--- a/packages/browser/src/openai/index.ts
+++ b/packages/browser/src/openai/index.ts
@@ -96,6 +96,9 @@ export type RealtimeSession = components["schemas"]["RealtimeSession"]
 export type RealtimeSessionCreateRequest =
   components["schemas"]["RealtimeSessionCreateRequest"]
 
+export type RealtimeSessionCreateResponse =
+  components["schemas"]["RealtimeSessionCreateResponse"]
+
 export type RealTimeSessionModels = RealtimeSessionCreateRequest["model"]
 
 /** Part of the @see RealtimeServerEventResponseDone event and others.


### PR DESCRIPTION

BREAKING CHANGE: The sessionRequest argument is no longer part of the constructor. The sessionRequested argument is no longe provided to the getRealtimeEphemeralAPIKey callback. The host application should know what session it wants and can always request whatever session it wants in the getRealtimeEphemeralAPIKey. See the WebRTC example for how to do this.

The hosting application is expected to manage the session request. This has presented a cleaner and more reliable API for us in production.